### PR TITLE
Mp matcher

### DIFF
--- a/readme_matcher_cli.md
+++ b/readme_matcher_cli.md
@@ -5,20 +5,21 @@ This CLI can be used to match the predicted metabolic products with experimental
 ## Command Line Interface
 
 ```bash
-matcher_cli <MS_DATA> <COMPOUNDS_TO_MATCH> <OUTPUT_DIRECTORY> [--tolerance=<FLOAT>]
+matcher_cli <MS_DATA> <COMPOUNDS_TO_MATCH> <OUTPUT_DIRECTORY> [--tolerance=<FLOAT>] [--n_jobs=<INT>]
 ```
 
-| Argument                                 | Example               | Description                                                                        | Default                                                                                                                                            |
-|------------------------------------------|-----------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| ms_data <MS_DATA>                        | `ms_data.tsv`         | The path to the file containing the MS data.                                       |                                                                                                                                                    |
-| compounds_to_match <COMPOUNDS_TO_MATCH>  | `file.tsv`            | The path to the file containing the predicted compounds to match with the MS data. |                                                                                                                                                    |
- | output_directory <OUTPUT_DIRECTORY>      | `output/directory/`   | The path directory to save the results to.                                         |                                                                                                                                                    |
-| tolerance                                | `0.02`                | The mass tolerance to use when matching masses.                                    | `0.02`                                                                                                                                             |
+| Argument                                | Example             | Description                                                                             | Default |
+|-----------------------------------------|---------------------|-----------------------------------------------------------------------------------------|---------|
+| ms_data <MS_DATA>                       | `ms_data.tsv`       | The path to the file containing the MS data.                                            |         |
+| compounds_to_match <COMPOUNDS_TO_MATCH> | `file.tsv`          | The path to the file containing the predicted compounds to match with the MS data.      |         |
+ | output_directory <OUTPUT_DIRECTORY>     | `output/directory/` | The path directory to save the results to.                                              |         |
+| tolerance                               | `0.02`              | The mass tolerance to use when matching masses.                                         | `0.02`  |
+| n_jobs                                  | `6`                 | The number of jobs to run in parallel (-1 uses all).                                    | `1`     |
 
 More detailed information on these arguments and possible usages can be consulted in the main [README](README.md).
 
 ## Example:
 
 ```bash
-matcher_cli ms_data.tsv compounds_to_match.tsv output_directory/ --tolerance=0.0015
+matcher_cli ms_data.tsv compounds_to_match.tsv output_directory/ --tolerance=0.0015 --n_jobs=-1
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click==8.1.3
 pandas==1.5.1
 numpy==1.23.3
 tqdm==4.64.1
+pandarallel==1.6.3

--- a/src/biocatalyzer/_utils.py
+++ b/src/biocatalyzer/_utils.py
@@ -1,4 +1,3 @@
-import os.path
 from typing import List
 
 import numpy as np

--- a/src/biocatalyzer/bioreactor.py
+++ b/src/biocatalyzer/bioreactor.py
@@ -498,6 +498,8 @@ class BioReactor:
         bool
             True if mol matches conditions to remove, False otherwise.
         """
+        if '*' in smiles:
+            return False
         if self._min_atom_count > 0:
             if not self._min_atom_count_filter(smiles):
                 return False
@@ -620,7 +622,7 @@ class BioReactor:
 
 if __name__ == '__main__':
     output_path_ = 'results/results_example/'
-    br = BioReactor(compounds_path='data/compounds/drugs_paper_subset.csv',
+    br = BioReactor(compounds_path='data/compounds/drugs.csv',
                     output_path=output_path_,
                     organisms_path='data/organisms/organisms_to_use.tsv',
                     patterns_to_remove_path='data/patterns_to_remove/patterns.tsv',

--- a/src/biocatalyzer/chem/_utils.py
+++ b/src/biocatalyzer/chem/_utils.py
@@ -1,7 +1,7 @@
 def _correct_number_of_parenthesis(smiles: str):
     """
     Corrects the number of parenthesis of a SMILES string.
-    Sometimes the react method returns a SMILES string with an incorrect number of parenthesis.
+    Sometimes some output SMILES string with an incorrect number of parenthesis are generated.
     This method corrects that issue.
 
     Parameters

--- a/src/biocatalyzer/clis/cli.py
+++ b/src/biocatalyzer/clis/cli.py
@@ -126,7 +126,8 @@ def biocatalyzer_cli(compounds,
             ms = MSDataMatcher(ms_data_path=ms_data_path,
                                compounds_to_match_path=new_results_path,
                                output_path=output_path,
-                               tolerance=tolerance)
+                               tolerance=tolerance,
+                               n_jobs=n_jobs)
 
             ms.generate_ms_results()
 

--- a/src/biocatalyzer/clis/cli_matcher.py
+++ b/src/biocatalyzer/clis/cli_matcher.py
@@ -25,10 +25,18 @@ from biocatalyzer import MSDataMatcher
               show_default=True,
               help="The mass tolerance to use when matching MS data.",
               )
+@click.option("--n_jobs",
+              "n_jobs",
+              type=int,
+              default=1,
+              show_default=True,
+              help="The number of jobs to run in parallel.",
+              )
 def matcher_cli(ms_data,
                 compounds_to_match,
                 output_path,
-                tolerance):
+                tolerance,
+                n_jobs):
     """Run the MSDataMatcher.
 
     Mandatory arguments:
@@ -42,7 +50,8 @@ def matcher_cli(ms_data,
     ms = MSDataMatcher(ms_data_path=ms_data,
                        compounds_to_match_path=compounds_to_match,
                        output_path=output_path,
-                       tolerance=tolerance)
+                       tolerance=tolerance,
+                       n_jobs=n_jobs)
     logging.basicConfig(filename=f'{output_path}_logging.log', level=logging.DEBUG)
     ms.generate_ms_results()
 

--- a/src/biocatalyzer/data/compounds/drugs.csv
+++ b/src/biocatalyzer/data/compounds/drugs.csv
@@ -2,3 +2,5 @@ smiles	compound_id
 CN1C=NC2=C1C(=O)N(C(=O)N2C)C	Caffeine
 C(C1C(C(C(C(O1)O)O)O)O)O	D-Glucose
 CC(=O)OC1=CC=CC=C1C(=O)O	Aspirin
+Nc1nc(NC2CC2)c2ncn(C3C=CC(CO)C3)c2n1	ABACAVIR SULFATE
+CCCC(=O)Nc1ccc(OCC(O)C[NH2+]C(C)C)c(C(C)=O)c1	ACEBUTOLOL

--- a/src/biocatalyzer/data/patterns_to_remove/patterns.tsv
+++ b/src/biocatalyzer/data/patterns_to_remove/patterns.tsv
@@ -7,4 +7,3 @@ S-Adenosyl methionine et al.	**1*(*)*(O*1CS*)[R]
 Flavin compounds	**1**2**3*(**(=O)**3=O)*(*)*2**1*
 Hemes	*~1~*~*~2~*~*~1~*~*~1~*~*~*(~*~*~3~*~*~*(~*~*~4~*~*~*(~*~2)~*~4)~*~3)~*~1
 Iron-sulfur cluster(s)	S1[Fe]S[Fe]1
-compounds with wildcard char	*

--- a/tests/unit_tests/test_bioreactor.py
+++ b/tests/unit_tests/test_bioreactor.py
@@ -58,7 +58,7 @@ class TestBioReactor(BioReactorTestCase, TestCase):
             _ = br_no_orgs_filter.new_compounds
 
         r = br_no_orgs_filter.process_results(False)
-        self.assertEqual(r[0].shape, (3221, 7))
+        self.assertEqual(r[0].shape, (3220, 7))
 
     def test_bioreactor_all_orgs_keep_all(self):
         compounds_path = os.path.join(TESTS_DATA_PATH, 'compounds_sample/compounds.tsv')


### PR DESCRIPTION
Add multiprocessing to the matcher pipeline.
Fix the bug where all new products were removed because they matched pattern `*`.
Now the `*` presence or absence is done directly on the smiles string.